### PR TITLE
Various script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,17 @@ The procedure consists of 4 steps:
 5. Optional: serve different overlays (configs) for each Pi you have
 6. Optional: add kernel modules to the initramfs
 
-### Prerequisities
+### Prerequisites
 Three variables need to be set at the top of the script:
 
-`VERSION` and `RELEASE`: the Alpine Linux version and dot release to be installed.
-
-`TFTP_IP`: the IP address of the TFTP server (if you use the included script, this is the address of the machine you're currently on).
+`VERSION` and `RELEASE`: the Alpine Linux version and dot release to be installed. You can also specify `VERSION=latest-stable` and the script will always pull the last stable Alpine release.
 
 `HTTP_IP`: the IP address of the HTTP server (both TFTP and HTTP servers can run on the same machine/IP,
 and if you use the included script, this is the address of the machine you're currently on).
 
 On top of setting these variables you need `python3` to serve the http folder, and `dnsmasq` to serve the tftp folder with the included scripts.
 Alternatively you could use an HTTP server like apache or nginx, and a TFTP server like tftpd-hpa or atftpd.
-Further the script is using `wget`, `tar`, `unsquashfs`, `cpio`, and `gzip`, so check if those are available on your system.
+Further the script is using `wget`, `tar`, `unsquashfs`, `cpio`, `gzip`, and `yq`, so check if those are available on your system.
 
 
 ## Step 1: Prepare the Raspberry Pi 4
@@ -93,7 +91,7 @@ and reboot your Pi.
 
 
 ## Step 5: (Optional / Advanced) Create different overlays (configurations) for individual Pi's
-In most cases, having multiple Pi's means they need to do different tasks. It is very usefull to have different configurations sent to them,
+In most cases, having multiple Pi's means they need to do different tasks. It is very useful to have different configurations sent to them,
 instead of having one big 'one size fits all' overlay for all of them.
 To achieve this, the individual Pi's need to be sent a unique `cmdline.txt` file pointing to a individual overlay tarball in the `apkovl` variable.
 You might have noticed in the `dnsmasq` output or your TFTP server logs that the Pi is first searching for the start4.elf file in a subfolder

--- a/create_tftp_http_dirs.sh
+++ b/create_tftp_http_dirs.sh
@@ -11,20 +11,19 @@ set -euo pipefail
 
 #####
 # change these values to match your setup
-VERSION=3.12
-RELEASE=1
-TFTP_IP=192.168.1.2
-HTTP_IP=192.168.1.2
+ALPINE_VERSION=3.12
+ALPINE_RELEASE=1
+HTTP_SERVER_IP=192.168.1.2
 
 MODULES_INITRAMFS=("net/packet/af_packet.ko") # af_packet.ko is necessary, add additional if required
 
 #####
 # download the release, if not already present
-REL_TAR=alpine-rpi-${VERSION}.${RELEASE}-aarch64.tar.gz
+REL_TAR=alpine-rpi-${ALPINE_VERSION}.${ALPINE_RELEASE}-aarch64.tar.gz
 WORKDIR=$(pwd)
 if [ ! -e ${REL_TAR} ]
 then
-	wget http://dl-cdn.alpinelinux.org/alpine/v${VERSION}/releases/aarch64/${REL_TAR}
+	wget https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/releases/aarch64/${REL_TAR}
 fi
 
 
@@ -59,7 +58,7 @@ arm_64bit=1
 EOF
 
 cat << EOF >> cmdline.txt
-modules=loop,squashfs console=ttyS0,115200 ip=dhcp alpine_repo=http://${HTTP_IP}/alpine/v${VERSION}/main apkovl=http://${HTTP_IP}/overlay.tar.gz
+modules=loop,squashfs console=ttyS0,115200 ip=dhcp alpine_repo=http://${HTTP_SERVER_IP}/alpine/v${ALPINE_VERSION}/main apkovl=http://${HTTP_SERVER_IP}/overlay.tar.gz
 EOF
 
 cat << EOF >> dnsmasq_tftpserver.sh

--- a/create_tftp_http_dirs.sh
+++ b/create_tftp_http_dirs.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2164,SC1039
+set -euo pipefail
 
 # This script will prepare two directories for netbooting Alpine Linux to a Raspberry Pi 4B.
 # One directory should be served over TFTP, the other over HTTP
@@ -29,13 +31,13 @@ fi
 #####
 # create files to be served over TFTP
 echo "* preparing TFTP folder"
-cd ${WORKDIR}
+cd "${WORKDIR}"
 mkdir tftp; cd tftp
 tar xvzf ../${REL_TAR} ./start4.elf # primary bootloader
 tar xvzf ../${REL_TAR} ./fixup4.dat # SDRAM setup
 tar xvzf ../${REL_TAR} ./bcm2711-rpi-4-b.dtb # device tree blob
 tar xvzf ../${REL_TAR} ./boot/vmlinuz-rpi4 # kernel
-ln -s boot/vmlinuz-rpi4
+ln -s boot/vmlinuz-rpi4 .
 
 # the initramfs needs af_packet.ko added:
 tar xvzf ../${REL_TAR} ./boot/modloop-rpi4 # kernel modules
@@ -70,7 +72,7 @@ chmod +x dnsmasq_tftpserver.sh
 #####
 # create files to be served over HTTP
 echo "* preparing HTTP folder"
-cd ${WORKDIR}
+cd "${WORKDIR}"
 tar xvzf ${REL_TAR} ./apks/
 mv apks http
 
@@ -85,7 +87,7 @@ mv apks http
 #         └── default
 #             └── local -> /etc/init.d/local
 echo "* creating initial overlay"
-cd ${WORKDIR}
+cd "${WORKDIR}"
 OVERLAY_DIR=overlay_ssh
 mkdir ${OVERLAY_DIR}; cd ${OVERLAY_DIR}
 
@@ -128,11 +130,11 @@ touch etc/.default_boot_services
 
 mkdir -p etc/runlevels/default
 cd etc/runlevels/default
-ln -s /etc/init.d/local
-cd ${WORKDIR}/${OVERLAY_DIR}
+ln -s /etc/init.d/local .
+cd "${WORKDIR}/${OVERLAY_DIR}"
 tar czvf overlay_ssh.tar.gz etc/
-cd ${WORKDIR}/http
-ln -s ../${OVERLAY_DIR}/overlay_ssh.tar.gz overlay.tar.gz
+cd "${WORKDIR}/http"
+ln -s "../${OVERLAY_DIR}/overlay_ssh.tar.gz" overlay.tar.gz
 
 cat << EOF >> python3_httpserver.sh
 #!/usr/bin/env bash

--- a/create_tftp_http_dirs.sh
+++ b/create_tftp_http_dirs.sh
@@ -48,15 +48,15 @@ fi
 echo "* preparing TFTP folder"
 cd "${WORKDIR}"
 mkdir -p tftp; cd tftp
-tar xvzf ../${REL_TAR} ./start4.elf # primary bootloader
-tar xvzf ../${REL_TAR} ./fixup4.dat # SDRAM setup
-tar xvzf ../${REL_TAR} ./bcm2711-rpi-4-b.dtb # device tree blob
-tar xvzf ../${REL_TAR} ./boot/vmlinuz-rpi4 # kernel
+tar xvzf "../${REL_TAR}" ./start4.elf # primary bootloader
+tar xvzf "../${REL_TAR}" ./fixup4.dat # SDRAM setup
+tar xvzf "../${REL_TAR}" ./bcm2711-rpi-4-b.dtb # device tree blob
+tar xvzf "../${REL_TAR}" ./boot/vmlinuz-rpi4 # kernel
 ln -s boot/vmlinuz-rpi4 . 2>/dev/null || true
 
 # the initramfs needs af_packet.ko added:
-tar xvzf ../${REL_TAR} ./boot/modloop-rpi4 # kernel modules
-tar xvzf ../${REL_TAR} ./boot/initramfs-rpi4 # initramfs
+tar xvzf "../${REL_TAR}" ./boot/modloop-rpi4 # kernel modules
+tar xvzf "../${REL_TAR}" ./boot/initramfs-rpi4 # initramfs
 mkdir -p modloop-rpi4
 unsquashfs -f -d modloop-rpi4/lib boot/modloop-rpi4 'modules/*/modules.*'
 for mod in "${MODULES_INITRAMFS[@]}"
@@ -89,7 +89,7 @@ chmod +x dnsmasq_tftpserver.sh
 echo "* preparing HTTP folder"
 cd "${WORKDIR}"
 mkdir -p http/apks
-tar xvzf ${REL_TAR} ./apks/
+tar xvzf "${REL_TAR}" ./apks/
 cp -R apks/* http/apks/
 rm -R apks/
 


### PR DESCRIPTION
Hi, not sure if you're taking PRs for this script, made some small improvements for my use case:

- Ran the script through `shellcheck` and fixed some minor issues (quotes around variables)
- Uses `https` for downloading Alpine, verifies sha256 checksum of download
- Script runs now idempotent (running the script multiple times will not change the result)
- You can now specify `VERSION=latest-stable` instead (requires `yq`) to fetch Alpine release information and always pull the latest stable release.